### PR TITLE
Update to version v1.1.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Please complete the following information about the solution:**
+- [ ] Version: [e.g. v1.1.1]
+
+To get the version of the solution, you can look at the description of the created CloudFormation stack. For example, "_Amazon S3 Glacier Re:Freezer. Version **v1.1.1**_".
+
+- [ ] Region: [e.g. us-east-1]
+- [ ] Was the solution modified from the version published on this repository?
+- [ ] If the answer to the previous question was yes, are the changes available on GitHub?
+- [ ] Have you checked your [service quotas](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) for the sevices this solution uses?
+- [ ] Were there any errors in the CloudWatch Logs?
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem (please **DO NOT include sensitive information**).
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this solution
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the feature you'd like**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+*Issue #, if available:*
+
+*Description of changes:*
+
+By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,140 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+open-source/
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+.DS_Store
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# editors
+.idea
+.vscode
+
+# cdk
+cdk.out
+deployment/global-s3-assets
+deployment/regional-s3-assets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2024-04-04
+
+### Added
+
+- Allow referencing an external destination bucket.
+- Add SQS metrics widgets to CloudWatch dashboard to have a way to monitor the progress of the transfer
+- Add a pre-built CloudWatch Logs Insights query for Lambdas errors
+
+### Updated
+
+- Implement retry within MetricsProcessor Lambda when encountering TransactionConflict exception
+- Use SHA-256 to generate TransactWriteItems ClientRequestToken as a more secure alternative to MD5 hashing
+- Add try-except block around the archive naming logic to prevent the entire Glue job from failing due to a single/few names parsing errors.
+- Enhance SSM Automation documents descriptions
+- Add user-agents to all service clients to track usage on solution service API usage dashboard
+
+### Fixed
+
+- Fix Glue jobs that are not generating CloudWatch logs
+- Fix Glue job failures occurring when description fields contain UTF-8 encoded characters
+- Fix duplicate archive names when there are identical archive names with the same creation time
+
 ## [1.0.0] - 2023-12-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Data Transfer from Amazon S3 Glacier vaults to Amazon S3
+# Data transfer from Amazon S3 Glacier vaults to Amazon S3
 
-The Data Transfer from Amazon S3 Glacier vaults to Amazon S3 is a serverless solution that automatically copies entire Amazon S3 Glacier vault archives to a defined destination Amazon Simple Storage Service (Amazon S3 bucket) and S3 storage class.
+Data transfer from Amazon S3 Glacier vaults to Amazon S3 is a serverless solution that automatically copies entire Amazon S3 Glacier vault archives to a defined destination Amazon Simple Storage Service (Amazon S3 bucket) and S3 storage class.
 
 The solution automates the optimized restore, copy, and transfer process and provides a prebuilt Amazon CloudWatch dashboard to visualize the copy operation progress. Deploying this solution allows you to seamlessly copy your S3 Glacier vault archives to more cost effective storage locations such as the Amazon S3 Glacier Deep Archive storage class.
 
 Copying your Amazon S3 Glacier vault contents to the S3 Glacier Deep Archive storage class combines the low cost and high durability benefits of S3 Glacier Deep Archive, with the familiar Amazon S3 user and application experience that offers simple visibility and access to data. Once your archives are stored as objects in your Amazon S3 bucket, you can add tags to your data to enable items such as attributing data costs on a granular level.
 
-_Note: The solution only copies archives from a source S3 Glacier vault to
-the destination S3 bucket, it does not delete archives in the source S3 Glacier vault. After the solution completes a successful archive copy to the destination S3 bucket, you must manually delete the archives from your S3 Glacier vault.For more information,
-refer to [Deleting an Archive in Amazon S3 Glacier](https://docs.aws.amazon.com/amazonglacier/latest/dev/deleting-an-archive.html) in the Amazon S3 Glacier Developer Guide._
+ _Note: The solution only copies archives from a source S3 Glacier vault to
+ the destination S3 bucket, it does not delete archives in the source S3 Glacier vault. After the solution completes a successful archive copy to the destination S3 bucket, you must manually delete the archives from your S3 Glacier vault.For more information,
+ refer to [Deleting an Archive in Amazon S3 Glacier](https://docs.aws.amazon.com/amazonglacier/latest/dev/deleting-an-archive.html) in the Amazon S3 Glacier Developer Guide._
 
 ## Table of contents
 
@@ -23,7 +23,7 @@ refer to [Deleting an Archive in Amazon S3 Glacier](https://docs.aws.amazon.com/
 
 ## Architecture
 
-![Data Transfer from Glacier vaults to S3](./architecture.png)
+![Data transfer from Glacier vaults to S3](./architecture.png)
 
 1. Customers invoke a transfer workflow by using an AWS Systems Manager
    document (SSM document).
@@ -89,7 +89,11 @@ pip install ".[dev]"
 
 #### 4. Deploy the solution using CDK
 
-Make sure AWS CLI is operational ([see here](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html))
+Make sure AWS CLI is operational ([see here](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)).
+
+Before deploying the stack, it is necessary to create a destination S3 bucket where the archives will be transferred. 
+The name of this bucket should be specified via a CloudFormation parameter *DestinationBucketParameter*.
+
 
 ```
 aws s3 ls
@@ -104,23 +108,23 @@ npx cdk bootstrap
 Deploy the solution
 
 ```
-npx cdk deploy solution -c skip_integration_tests=true
+npx cdk deploy solution --parameters DestinationBucketParameter=my-output-bucket-name
 ```
 
-_note: set context parameter `skip_integration_tests=false` to indicate if you want to run integration tests against the solution stack_
+_note: set context parameter `skip_integration_tests` to `false` to indicate if you want to run integration tests against the solution stack: `npx cdk deploy solution -c skip_integration_tests=false --parameters DestinationBucketParameter=my-output-bucket-name`._
 
 #### 5. Running integration tests
 
 ```
 npx cdk deploy mock-glacier
 export MOCK_SNS_STACK_NAME=mock-glacier # use mock-glacier stack name
-export $STACK_NAME=solution # use solution stack name
+export STACK_NAME=solution # use solution stack name
 tox -e integration
 ```
 
 ## Automated testing pipeline
 
-The Data Transfer from S3 Glacier vaults to S3 includes an optional automated testing pipeline that can be deployed to automatically test any
+The Data transfer from S3 Glacier vaults to S3 includes an optional automated testing pipeline that can be deployed to automatically test any
 changes you develop for the solution on your own development fork. Once setup, this pipeline will automatically
 download, build, and test any changes that you push to a specified branch on your development fork.
 
@@ -131,7 +135,7 @@ The pipeline can be configured to automatically watch and pull from repos hosted
 - Create the pipeline
 
 ```
-npx cdk deploy pipeline -c repository_name=my-repo -c branch=dev
+npx cdk deploy pipeline -c repository_name=my-repo -c branch=dev -c skip_integration_tests=false -c output_bucket_name=my-output-bucket-name
 ```
 
 The pipeline will be triggered any time you make a push to the codecommit repository on the identified branch.
@@ -154,7 +158,7 @@ _note: due to a known issue where resource name gets truncated, we recommend bra
 
 ## CDK Documentation
 
-Data Transfer from Amazon S3 Glacier vaults to Amazon S3 templates are
+Data transfer from Amazon S3 Glacier vaults to Amazon S3 templates are
 generated using AWS CDK, for further information on CDK please refer to the
 [documentation](https://docs.aws.amazon.com/cdk/latest/guide/getting_started.html).
 

--- a/cdk.json
+++ b/cdk.json
@@ -38,10 +38,10 @@
     "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
     "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
     "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
-    "SOLUTION_NAME": "Data Transfer from Amazon S3 Glacier vaults to Amazon S3",
+    "SOLUTION_NAME": "Data transfer from Amazon S3 Glacier vaults to Amazon S3",
     "APP_REGISTRY_NAME": "data_retrieval_for_amazon_glacier_s3",
     "SOLUTION_ID": "SO0293",
-    "SOLUTION_VERSION": "v1.0.0",
+    "SOLUTION_VERSION": "v1.1.0",
     "APPLICATION_TYPE": "AWS-Solutions"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ package-dir = {"" = "source"}
 
 [project]
 name = "solution"
-version = "1.0.0"
-description = "Data Transfer from Amazon S3 Glacier vaults to Amazon S3"
+version = "1.1.0"
+description = "Data transfer from Amazon S3 Glacier vaults to Amazon S3"
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "Apache Software License"}
@@ -40,8 +40,8 @@ mock-glacier = "solution.application.mocking.mock_glacier_generator:write_mock_g
 [project.optional-dependencies]
 dev = [
     "tox",
-    "black",
-    "pytest",
+    "black==23.12.1",
+    "pytest==7.4.3",
     "pytest-cov",
     "cdk-nag",
     "mypy==1.7.1",
@@ -56,8 +56,10 @@ dev = [
     "boto3-stubs-lite[iam]",
     "boto3-stubs-lite[stepfunctions]",
     "boto3-stubs-lite[glacier]",
+    "boto3-stubs-lite[events]",
     "pyspark",
     "boto3-stubs-lite[ssm]",
+    "boto3-stubs[logs]",
     "types-pyyaml"
 ]
 

--- a/source/solution/application/__init__.py
+++ b/source/solution/application/__init__.py
@@ -1,0 +1,14 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from importlib import metadata
+
+from botocore.config import Config
+
+__version__ = metadata.version("solution")
+__solution_id__ = "SO0293"
+__boto_config__ = Config(
+    user_agent_extra=f"AwsSolution/{__solution_id__}/v{__version__}"
+)

--- a/source/solution/application/archive_naming/override.py
+++ b/source/solution/application/archive_naming/override.py
@@ -15,22 +15,24 @@ if TYPE_CHECKING:
 else:
     S3Client = object
 
+from solution.application import __boto_config__
 from solution.infrastructure.output_keys import OutputKeys
 
 
 def create_header_file(workflow_run: str) -> None:
-    s3_client: S3Client = boto3.client("s3")
+    s3_client: S3Client = boto3.client("s3", config=__boto_config__)
     file_name = f"{workflow_run}/naming_overrides/override_headers.csv"
 
     s3_client.put_object(
         Body=b"GlacierArchiveID,FileName\n,",
         Bucket=os.environ[OutputKeys.INVENTORY_BUCKET_NAME],
         Key=file_name,
+        ExpectedBucketOwner=os.environ["AWS_ACCOUNT_ID"],
     )
 
 
 def upload_provided_file(workflow_run: str, presigned_url: str) -> None:
-    s3_client: S3Client = boto3.client("s3")
+    s3_client: S3Client = boto3.client("s3", config=__boto_config__)
     with urllib.request.urlopen(presigned_url) as response:
         content = response.read()
         s3_client.upload_fileobj(

--- a/source/solution/application/archive_retrieval/timeout.py
+++ b/source/solution/application/archive_retrieval/timeout.py
@@ -16,7 +16,7 @@ from solution.application.model.partition_metric_record import PartitionMetricRe
 from solution.infrastructure.output_keys import OutputKeys
 
 logger = logging.getLogger()
-logger.setLevel(logging.INFO)
+logger.setLevel(int(os.environ.get("LOGGING_LEVEL", logging.INFO)))
 
 
 def calculate_timeout(workflow_run: str) -> int:

--- a/source/solution/application/completion/checker.py
+++ b/source/solution/application/completion/checker.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 import boto3
 
+from solution.application import __boto_config__
 from solution.application.model.facilitator import AsyncRecord, JobCompletionEvent
 from solution.application.model.metric_record import MetricRecord
 from solution.infrastructure.output_keys import OutputKeys
@@ -21,11 +22,11 @@ else:
 
 
 logger = logging.getLogger()
-logger.setLevel(logging.INFO)
+logger.setLevel(int(os.environ.get("LOGGING_LEVEL", logging.INFO)))
 
 
 def check_workflow_completion(workflow_run: str) -> str:
-    ddb_client: DynamoDBClient = boto3.client("dynamodb")
+    ddb_client: DynamoDBClient = boto3.client("dynamodb", config=__boto_config__)
     if is_workflow_completed(workflow_run, ddb_client):
         job_id = f"{workflow_run}|COMPLETION"
         async_record = AsyncRecord(

--- a/source/solution/application/db_accessor/dynamoDb_accessor.py
+++ b/source/solution/application/db_accessor/dynamoDb_accessor.py
@@ -4,9 +4,12 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import logging
+import os
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import boto3
+
+from solution.application import __boto_config__
 
 if TYPE_CHECKING:
     from mypy_boto3_dynamodb import DynamoDBClient
@@ -14,12 +17,16 @@ else:
     DynamoDBClient = object
 
 logger = logging.getLogger()
-logger.setLevel(logging.INFO)
+logger.setLevel(int(os.environ.get("LOGGING_LEVEL", logging.INFO)))
 
 
 class DynamoDBAccessor:
-    def __init__(self, table_name: str) -> None:
-        self.dynamodb: DynamoDBClient = boto3.client("dynamodb")
+    def __init__(
+        self, table_name: str, client: Optional[DynamoDBClient] = None
+    ) -> None:
+        self.dynamodb: DynamoDBClient = client or boto3.client(
+            "dynamodb", config=__boto_config__
+        )
         self.table_name = table_name
 
     def insert_item(self, item: Dict[str, Any]) -> None:

--- a/source/solution/application/facilitator/processor.py
+++ b/source/solution/application/facilitator/processor.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 import boto3
 
+from solution.application import __boto_config__
 from solution.application.model.facilitator import AsyncRecord, JobCompletionEvent
 from solution.infrastructure.output_keys import OutputKeys
 
@@ -20,7 +21,7 @@ else:
     SFNClient = object
 
 logger = logging.getLogger()
-logger.setLevel(logging.INFO)
+logger.setLevel(int(os.environ.get("LOGGING_LEVEL", logging.INFO)))
 
 
 def handle_job_notification(message: str) -> None:
@@ -55,7 +56,7 @@ def handle_record_changed(attributes: dict[str, Any]) -> None:
 
 
 def update_record(record: AsyncRecord) -> None:
-    client: DynamoDBClient = boto3.client("dynamodb")
+    client: DynamoDBClient = boto3.client("dynamodb", config=__boto_config__)
 
     update_parameters = record.inventory_job_completion_update_parameters
     client.update_item(
@@ -84,5 +85,5 @@ def notify_of_result(task_token: str, event: JobCompletionEvent) -> None:
 
 
 def get_sfn_client() -> SFNClient:
-    client: SFNClient = boto3.client("stepfunctions")
+    client: SFNClient = boto3.client("stepfunctions", config=__boto_config__)
     return client

--- a/source/solution/application/glacier_s3_transfer/facilitator.py
+++ b/source/solution/application/glacier_s3_transfer/facilitator.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 import boto3
 
+from solution.application import __boto_config__
 from solution.application.db_accessor.dynamoDb_accessor import DynamoDBAccessor
 from solution.application.glacier_s3_transfer.download import GlacierDownload
 from solution.application.glacier_s3_transfer.upload import S3Upload
@@ -44,7 +45,7 @@ else:
     GlacierRetrievalResponse = object
 
 logger = logging.getLogger()
-logger.setLevel(logging.INFO)
+logger.setLevel(int(os.environ.get("LOGGING_LEVEL", logging.INFO)))
 
 
 class GlacierToS3Facilitator:
@@ -149,7 +150,7 @@ class GlacierToS3Facilitator:
                 "Exiting send validation events: More chunks remain for download"
             )
             return None
-        sqs = boto3.client("sqs")
+        sqs = boto3.client("sqs", config=__boto_config__)
         validation_sqs_url = os.environ[OutputKeys.VALIDATION_SQS_URL]
         message_body = {
             "WorkflowRun": self.workflow_run,

--- a/source/solution/application/glacier_s3_transfer/multipart_cleanup.py
+++ b/source/solution/application/glacier_s3_transfer/multipart_cleanup.py
@@ -3,9 +3,12 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 """
 import logging
+import os
 from typing import TYPE_CHECKING
 
 import boto3
+
+from solution.application import __boto_config__
 
 if TYPE_CHECKING:
     from mypy_boto3_s3.type_defs import (
@@ -17,20 +20,21 @@ else:
     MultipartUploadTypeDef = object
 
 logger = logging.getLogger()
-logger.setLevel(logging.INFO)
+logger.setLevel(int(os.environ.get("LOGGING_LEVEL", logging.INFO)))
 
 
 class MultipartCleanup:
     def __init__(self, workflow_run: str, bucket_name: str):
         self.workflow_run = workflow_run
         self.bucket_name = bucket_name
-        self.client = boto3.client("s3")
+        self.client = boto3.client("s3", config=__boto_config__)
 
     def cleanup(self) -> int:
         open_uploads: ListMultipartUploadsOutputTypeDef = (
             self.client.list_multipart_uploads(
                 Bucket=self.bucket_name,
                 Prefix=self.workflow_run,
+                ExpectedBucketOwner=os.environ["AWS_ACCOUNT_ID"],
             )
         )
         if "Uploads" not in open_uploads:
@@ -43,5 +47,8 @@ class MultipartCleanup:
     def abort_upload(self, upload: MultipartUploadTypeDef) -> None:
         logger.info(f"Aborting upload: {upload['UploadId']}")
         self.client.abort_multipart_upload(
-            Bucket=self.bucket_name, Key=upload["Key"], UploadId=upload["UploadId"]
+            Bucket=self.bucket_name,
+            Key=upload["Key"],
+            UploadId=upload["UploadId"],
+            ExpectedBucketOwner=os.environ["AWS_ACCOUNT_ID"],
         )

--- a/source/solution/application/glacier_service/glacier_apis_factory.py
+++ b/source/solution/application/glacier_service/glacier_apis_factory.py
@@ -6,7 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 from typing import TYPE_CHECKING
 
 import boto3
-from botocore.config import Config
+
+from solution.application import __boto_config__
 
 if TYPE_CHECKING:
     from mypy_boto3_glacier.client import GlacierClient
@@ -34,6 +35,5 @@ class GlacierAPIsFactory:
             from solution.application.mocking.mock_glacier_apis import MockGlacierAPIs
 
             return MockGlacierAPIs()
-        config: Config = Config(user_agent_extra=f"AwsSolution/SO0293/v1.0.0")
-        client: GlacierClient = boto3.client("glacier", config=config)
+        client: GlacierClient = boto3.client("glacier", config=__boto_config__)
         return client

--- a/source/solution/application/mocking/mock_glacier_apis.py
+++ b/source/solution/application/mocking/mock_glacier_apis.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 import boto3
 from botocore.response import StreamingBody
 
+from solution.application import __boto_config__
 from solution.application.glacier_service.glacier_typing import GlacierJobType
 from solution.application.mocking.mock_glacier_data import MOCK_DATA
 
@@ -53,7 +54,7 @@ class MockGlacierAPIs(GlacierClient):
             access_string = f"{access_string}:{archive_id}"
         result = self.output_mapping[vaultName]["initiate-job"][access_string]
         if sns_topic := jobParameters.get("SNSTopic"):
-            client: LambdaClient = boto3.client("lambda")
+            client: LambdaClient = boto3.client("lambda", config=__boto_config__)
             function_params = {
                 "account_id": accountId,
                 "vault_name": vaultName,

--- a/source/solution/application/mocking/mock_glacier_vault.py
+++ b/source/solution/application/mocking/mock_glacier_vault.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import boto3
 
+from solution.application import __boto_config__
 from solution.application.glacier_service.glacier_typing import GlacierJobType
 from solution.application.hashing.tree_hash import TreeHash
 
@@ -28,7 +29,7 @@ else:
 class MockGlacierVault:
     def __init__(self, vault_name: str) -> None:
         self.vault_name = vault_name
-        self.glacier: GlacierClient = boto3.client("glacier")
+        self.glacier: GlacierClient = boto3.client("glacier", config=__boto_config__)
         self.glacier.create_vault(vaultName=vault_name)
         self.mock_vault_mapping: Dict[Any, Any] = {}
         self.inventory_job_id = ""

--- a/source/solution/application/operational_metrics/anonymized_stats.py
+++ b/source/solution/application/operational_metrics/anonymized_stats.py
@@ -17,7 +17,7 @@ from solution.application.model.workflow_metadata_model import WorkflowMetadataR
 from solution.infrastructure.output_keys import OutputKeys
 
 logger = logging.getLogger()
-logger.setLevel(logging.INFO)
+logger.setLevel(int(os.environ.get("LOGGING_LEVEL", logging.INFO)))
 
 SOLUTION_BUILDERS_ENDPOINT = "https://metrics.awssolutionsbuilder.com/generic"
 

--- a/source/solution/application/util/exceptions.py
+++ b/source/solution/application/util/exceptions.py
@@ -53,6 +53,8 @@ class InvalidLambdaParameter(Exception):
 
 
 class MaximumRetryLimitExceeded(Exception):
-    def __init__(self) -> None:
-        self.message = f"Maximum retry limit exceeded."
+    def __init__(self, max_retries: int, message: str) -> None:
+        self.message = (
+            f"Maximum retry limit {max_retries} exceeded. Exception: {message}"
+        )
         super().__init__(self.message)

--- a/source/solution/application/util/retry.py
+++ b/source/solution/application/util/retry.py
@@ -23,10 +23,11 @@ def retry(max_retries: int = 3, raise_exception: bool = False) -> Callable[..., 
                 except Exception as e:
                     logger.error(f"Exception occurred: {str(e)}")
                     logger.error(f"Retrying... (Attempt {retry + 1}/{max_retries})")
+                    last_exception = e
             else:
-                logger.info("Maximum retry limit exceeded. Exiting...")
+                logger.info(f"Maximum retry limit {max_retries} exceeded. Exiting...")
                 if raise_exception:
-                    raise MaximumRetryLimitExceeded()
+                    raise MaximumRetryLimitExceeded(max_retries, str(last_exception))
 
         return wrapper
 

--- a/source/solution/infrastructure/glue_helper/glue_sfn_update.py
+++ b/source/solution/infrastructure/glue_helper/glue_sfn_update.py
@@ -410,6 +410,9 @@ class GlueSfnUpdate(object):
                     "--metric_table_name": self.metric_table,
                     "--migration_type.$": "$.migration_type",
                     "--inventory_bucket": self.s3_bucket_name,
+                    "--enable-job-insights": "true",
+                    "--enable-continuous-cloudwatch-log": "true",
+                    "--job-language": "python",
                 }
             ),
             result_path="$.glue_start_job_result",

--- a/source/solution/infrastructure/glue_helper/scripts/metric_collection_script.py
+++ b/source/solution/infrastructure/glue_helper/scripts/metric_collection_script.py
@@ -6,14 +6,16 @@ SPDX-License-Identifier: Apache-2.0
 from typing import Any, Dict, List
 
 import boto3
-import botocore
+from botocore.config import Config
+
+__boto_config__ = Config(user_agent_extra="AwsSolution/SO0293/v1.1.0")
 
 
 def update_metric_table(
     pk: str, table_name: str, migration_type: str, dfc: Dict[str, Any]
 ) -> None:
     node_inputs = list(dfc.values())
-    client = boto3.client("dynamodb")
+    client = boto3.client("dynamodb", config=__boto_config__)
     if migration_type == "LAUNCH":
         _update_metric_table_for_new_run(node_inputs, pk, client, table_name)
     else:

--- a/source/solution/infrastructure/helpers/logs_insights_query.py
+++ b/source/solution/infrastructure/helpers/logs_insights_query.py
@@ -1,0 +1,100 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from typing import List
+
+from aws_cdk import Aws, CfnOutput, Fn
+from aws_cdk import aws_logs as logs
+
+from solution.application.model.glacier_transfer_model import GlacierTransferModel
+from solution.application.util.exceptions import ResourceNotFound
+from solution.infrastructure.output_keys import OutputKeys
+from solution.infrastructure.workflows.stack_info import StackInfo
+
+
+class LogsInsightsQuery:
+    def __init__(self, stack_info: StackInfo) -> None:
+        if stack_info.lambdas.initiate_archive_retrieval_lambda is None:
+            raise ResourceNotFound("Initiate archive retrievalLambda")
+        if stack_info.lambdas.notifications_processor_lambda is None:
+            raise ResourceNotFound("Notifications processor Lambda")
+        if stack_info.lambdas.chunk_retrieval_lambda is None:
+            raise ResourceNotFound("Chunk retrieval Lambda")
+        if stack_info.lambdas.archive_validation_lambda is None:
+            raise ResourceNotFound("Archive validation Lambda")
+        if stack_info.lambdas.metric_update_on_status_change_lambda is None:
+            raise ResourceNotFound("Metric update Lambda")
+        if stack_info.lambdas.archives_needing_window_extension_lambda is None:
+            raise ResourceNotFound("Archives needing extension Lambda")
+        if stack_info.lambdas.extend_download_window_initiate_retrieval_lambda is None:
+            raise ResourceNotFound("Extend download window Lambda")
+
+        log_group_names = [
+            f"/aws/lambda/{stack_info.lambdas.initiate_archive_retrieval_lambda.function_name}",
+            f"/aws/lambda/{stack_info.lambdas.notifications_processor_lambda.function_name}",
+            f"/aws/lambda/{stack_info.lambdas.chunk_retrieval_lambda.function_name}",
+            f"/aws/lambda/{stack_info.lambdas.archive_validation_lambda.function_name}",
+            f"/aws/lambda/{stack_info.lambdas.metric_update_on_status_change_lambda.function_name}",
+            f"/aws/lambda/{stack_info.lambdas.archives_needing_window_extension_lambda.function_name}",
+            f"/aws/lambda/{stack_info.lambdas.extend_download_window_initiate_retrieval_lambda.function_name}",
+        ]
+
+        query_string = "fields @timestamp, @message, @logStream, @log \
+        | filter @message like /error/ or @message like /Error/ or @message like /ERROR/ \
+        | filter @message not like /segmentation fault Runtime/ \
+        | filter @message not like /TransactionConflict/ \
+        | sort by @timestamp desc"
+
+        stack_id = Fn.select(2, Fn.split("/", Aws.STACK_ID))
+
+        query_definition = logs.CfnQueryDefinition(
+            stack_info.scope,
+            "LambdaErrorQueryDefinition",
+            name=f"LambdasErrorQuery-{stack_id}",
+            query_string=query_string,
+            log_group_names=log_group_names,
+        )
+
+        stack_info.outputs[OutputKeys.LOGS_INSIGHTS_QUERY_NAME] = CfnOutput(
+            stack_info.scope,
+            OutputKeys.LOGS_INSIGHTS_QUERY_NAME,
+            value=query_definition.name,
+        )
+
+        log_group_names = [
+            f"/aws/lambda/{stack_info.lambdas.metric_update_on_status_change_lambda.function_name}"
+        ]
+        for status in (
+            GlacierTransferModel.StatusCode.REQUESTED,
+            GlacierTransferModel.StatusCode.STAGED,
+            GlacierTransferModel.StatusCode.DOWNLOADED,
+        ):
+            self.add_counter_query(stack_info, log_group_names, status)
+
+    def add_counter_query(
+        self, stack_info: StackInfo, log_group_names: List[str], status: str
+    ) -> None:
+        query_string = f"fields @timestamp, @message, @logStream, @log \
+        | filter @message like /counted_status:{status}/ \
+        | parse @message '[INFO]	*	*	Archive:*|* - counted_status:{status}' as parsed_time, parsed_id, parsed_workflow, parsed_archive \
+        | stats count_distinct(parsed_archive) as unique_downloaded_archives by parsed_workflow"
+
+        stack_id = Fn.select(2, Fn.split("/", Aws.STACK_ID))
+
+        query_definition = logs.CfnQueryDefinition(
+            stack_info.scope,
+            f"{status}CounterQueryDefinition",
+            name=f"{status}CounterQuery-{stack_id}",
+            query_string=query_string,
+            log_group_names=log_group_names,
+        )
+
+        stack_info.outputs[
+            f"LogsInsights{status.capitalize()}CounterQueryName"
+        ] = CfnOutput(
+            stack_info.scope,
+            f"LogsInsights{status.capitalize()}CounterQueryName",
+            value=query_definition.name,
+        )

--- a/source/solution/infrastructure/helpers/solutions_function.py
+++ b/source/solution/infrastructure/helpers/solutions_function.py
@@ -3,6 +3,7 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import logging
 from typing import Any
 
 import aws_cdk.aws_iam as iam
@@ -13,7 +14,7 @@ from constructs import Construct
 
 from solution.application.util.exceptions import ResourceNotFound
 
-DEFAULT_RUNTIME = Runtime.PYTHON_3_10
+DEFAULT_RUNTIME = Runtime.PYTHON_3_11
 
 
 class SolutionsPythonFunction(Function):
@@ -31,9 +32,12 @@ class SolutionsPythonFunction(Function):
         if not kwargs.get("role"):
             kwargs["role"] = self._create_role()
 
-        # set runtime to Python 3.10 unless a runtime is passed
+        # set runtime to Python 3.11 unless a runtime is passed
         if not kwargs.get("runtime"):
             kwargs["runtime"] = DEFAULT_RUNTIME
+
+        # create default environment variable LOGGING_LEVEL
+        kwargs.setdefault("environment", {})["LOGGING_LEVEL"] = str(logging.INFO)
 
         # initialize the parent Function
         super().__init__(scope, construct_id, **kwargs)

--- a/source/solution/infrastructure/output_keys.py
+++ b/source/solution/infrastructure/output_keys.py
@@ -53,3 +53,13 @@ class OutputKeys:
     GLACIER_RETRIEVAL_JOB_INDEX_NAME = "GlacierRetrievalJobIndexName"
     ARCHIVES_STATUS_CLEANUP_STATE_MACHINE_ARN = "ArchivesStatusCleanupStateMachineArn"
     MOCK_NOTIFY_SNS_LAMBDA_ARN = "MockNotifySnsLambdaArn"
+    CLOUDWATCH_DASHBOARD_UPDATE_RULE_NAME = "CloudWatchDashboardUpdateRuleName"
+    WORKFLOW_COMPLETION_CHECKER_RULE_NAME = "WorkflowCompletionCheckerRuleName"
+    EXTEND_DOWNLOAD_WINDOW_RULE_NAME = "ExtendDownloadWindowRuleName"
+    LOGS_INSIGHTS_QUERY_NAME = "LogsInsightsQueryName"
+    LOGS_INSIGHTS_REQUESTED_COUNTER_QUERY_NAME = "LogsInsightsRequestedCounterQueryName"
+    LOGS_INSIGHTS_STAGED_COUNTER_QUERY_NAME = "LogsInsightsStagedCounterQueryName"
+    LOGS_INSIGHTS_DOWNLOADED_COUNTER_QUERY_NAME = (
+        "LogsInsightsDownloadedCounterQueryName"
+    )
+    METRIC_UPDATE_LAMBDA_NAME = "MetricUpdateLambdaName"

--- a/source/solution/infrastructure/workflows/cloudwatch_dashboard_update.py
+++ b/source/solution/infrastructure/workflows/cloudwatch_dashboard_update.py
@@ -33,9 +33,22 @@ class Workflow:
     def __init__(self, stack_info: StackInfo) -> None:
         if stack_info.tables.metric_table is None:
             raise ResourceNotFound("Metric Table")
+        if stack_info.queues.chunks_retrieval_queue is None:
+            raise ResourceNotFound("Chunks Queue")
+        if stack_info.queues.validation_queue is None:
+            raise ResourceNotFound("Validation Queue")
+        if stack_info.queues.notifications_queue is None:
+            raise ResourceNotFound("Notifications Queue")
 
         self.scope = stack_info.scope
-        CwDashboard(self.scope)  # To create the CloudWatch Dashboard
+        CwDashboard(
+            self.scope,
+            [
+                ("Notifications Queue", stack_info.queues.notifications_queue),
+                ("Chunks retrieval Queue", stack_info.queues.chunks_retrieval_queue),
+                ("Validation Queue", stack_info.queues.validation_queue),
+            ],
+        )  # To create the CloudWatch Dashboard
 
         stack_info.eventbridge_rules.cloudwatch_dashboard_update_trigger = (
             eventbridge.Rule(
@@ -43,6 +56,14 @@ class Workflow:
                 "CloudWatchDashboardUpdate",
                 schedule=eventbridge.Schedule.expression("cron(0/5 * * * ? *)"),
             )
+        )
+
+        stack_info.outputs[
+            OutputKeys.CLOUDWATCH_DASHBOARD_UPDATE_RULE_NAME
+        ] = CfnOutput(
+            self.scope,
+            OutputKeys.CLOUDWATCH_DASHBOARD_UPDATE_RULE_NAME,
+            value=stack_info.eventbridge_rules.cloudwatch_dashboard_update_trigger.rule_name,
         )
 
         get_metrics_from_metric_table = tasks.DynamoGetItem(

--- a/source/solution/infrastructure/workflows/retrieve_archive.py
+++ b/source/solution/infrastructure/workflows/retrieve_archive.py
@@ -19,7 +19,7 @@ class Workflow:
             raise ResourceNotFound("Glacier retrieval table")
         if stack_info.tables.metric_table is None:
             raise ResourceNotFound("Metric table")
-        if stack_info.buckets.output_bucket is None:
+        if stack_info.interfaces.output_bucket is None:
             raise ResourceNotFound("Output bucket")
         if stack_info.policies.get_job_output_policy is None:
             raise ResourceNotFound("Get job output policy")
@@ -53,7 +53,7 @@ class Workflow:
             )
         )
 
-        stack_info.buckets.output_bucket.grant_put(
+        stack_info.interfaces.output_bucket.grant_put(
             stack_info.lambdas.chunk_retrieval_lambda
         )
 
@@ -114,7 +114,7 @@ class Workflow:
             stack_info.lambdas.archive_validation_lambda
         )
 
-        stack_info.buckets.output_bucket.grant_read_write(
+        stack_info.interfaces.output_bucket.grant_read_write(
             stack_info.lambdas.archive_validation_lambda
         )
 
@@ -151,13 +151,6 @@ class Workflow:
         )
 
         assert isinstance(
-            stack_info.buckets.output_bucket.node.default_child, CfnElement
-        )
-        output_bucket_logical_id = Stack.of(stack_info.scope).get_logical_id(
-            stack_info.buckets.output_bucket.node.default_child
-        )
-
-        assert isinstance(
             stack_info.tables.glacier_retrieval_table.node.default_child, CfnElement
         )
         glacier_retrieval_table_logical_id = Stack.of(stack_info.scope).get_logical_id(
@@ -178,7 +171,7 @@ class Workflow:
                     "id": "AwsSolutions-IAM5",
                     "reason": "It's necessary to have wildcard permissions for s3 put object, to allow for copying glacier archives over to s3 in any location",
                     "appliesTo": [
-                        f"Resource::<{output_bucket_logical_id}.Arn>/*",
+                        "Resource::arn:<AWS::Partition>:s3:::<DestinationBucketParameter>/*",
                         "Action::s3:Abort*",
                     ],
                 },
@@ -209,7 +202,7 @@ class Workflow:
                     "id": "AwsSolutions-IAM5",
                     "reason": "It's necessary to have wildcard permissions for s3 put object, to allow for copying glacier inventory over to s3 in any location",
                     "appliesTo": [
-                        f"Resource::<{output_bucket_logical_id}.Arn>/*",
+                        "Resource::arn:<AWS::Partition>:s3:::<DestinationBucketParameter>/*",
                         "Action::s3:Abort*",
                         "Action::s3:DeleteObject*",
                         "Action::s3:GetBucket*",
@@ -239,7 +232,7 @@ class Workflow:
             [
                 {
                     "id": "AwsSolutions-L1",
-                    "reason": "Python 3.10 is the latest version, but there is a bug in cdk-nag due to sorting",
+                    "reason": "Python 3.11 is the latest version, but there is a bug in cdk-nag due to sorting",
                 }
             ],
         )

--- a/source/solution/infrastructure/workflows/stack_info.py
+++ b/source/solution/infrastructure/workflows/stack_info.py
@@ -66,13 +66,18 @@ class Lambdas:
 
 @dataclass
 class Buckets:
-    output_bucket: s3.Bucket | None = field(default=None)
     inventory_bucket: s3.Bucket | None = field(default=None)
     access_logs_bucket: s3.Bucket | None = field(default=None)
 
 
 @dataclass
+class Interfaces:
+    output_bucket: s3.IBucket | None = field(default=None)
+
+
+@dataclass
 class Parameters:
+    destination_bucket_parameter: CfnParameter | None = field(default=None)
     enable_ddb_backup_parameter: CfnParameter | None = field(default=None)
     enable_step_function_logging_parameter: CfnParameter | None = field(default=None)
     enable_lambda_tracing_parameter: CfnParameter | None = field(default=None)
@@ -122,3 +127,4 @@ class StackInfo:
         default_factory=lambda: EventbridgeRules()
     )
     policies: Policies = field(default_factory=lambda: Policies())
+    interfaces: Interfaces = field(default_factory=lambda: Interfaces())

--- a/source/solution/pipeline/README.md
+++ b/source/solution/pipeline/README.md
@@ -1,4 +1,4 @@
-# Data Transfer from Amazon S3 Glacier vaults to Amazon S3 build pipeline
+# Data transfer from Amazon S3 Glacier vaults to Amazon S3 build pipeline
 
 This project utilizes cdk pipelines for setting up a development pipeline that builds, deploys, and tests the solution.
 

--- a/source/tests/integration/infrastructure/conftest.py
+++ b/source/tests/integration/infrastructure/conftest.py
@@ -10,15 +10,27 @@ import boto3
 import pytest
 from botocore.exceptions import ClientError
 from mypy_boto3_cloudformation import CloudFormationClient
+from mypy_boto3_dynamodb import DynamoDBClient
+from mypy_boto3_events.client import EventBridgeClient
 from mypy_boto3_iam import IAMClient
 from mypy_boto3_lambda import LambdaClient
+from mypy_boto3_logs import CloudWatchLogsClient
+from mypy_boto3_s3.client import S3Client
 from mypy_boto3_sns import SNSClient
+from mypy_boto3_ssm import SSMClient
+from mypy_boto3_stepfunctions import SFNClient
 
 from solution.infrastructure.output_keys import OutputKeys
 
-lambda_client: LambdaClient = boto3.client("lambda")
-sns_client: SNSClient = boto3.client("sns")
-iam_client: IAMClient = boto3.client("iam")
+if "AWS_PROFILE" in os.environ and "AWS_REGION" in os.environ:
+    session = boto3.Session(
+        profile_name=os.environ["AWS_PROFILE"],
+        region_name=os.environ["AWS_REGION"],
+    )
+else:
+    session = boto3.Session()
+
+iam_client: IAMClient = session.client("iam")
 lambdas_to_update_env_variables = [
     OutputKeys.CHUNK_RETRIEVAL_LAMBDA_NAME,
     OutputKeys.INITIATE_INVENTORY_RETRIEVAL_LAMBDA_NAME,
@@ -33,8 +45,58 @@ lambdas_to_update_invoke_permissions = [
 ]
 
 
+@pytest.fixture(scope="module")
+def sfn_client() -> SFNClient:
+    client: SFNClient = session.client("stepfunctions")
+    return client
+
+
+@pytest.fixture(scope="module")
+def sns_client() -> SNSClient:
+    client: SNSClient = session.client("sns")
+    return client
+
+
+@pytest.fixture(scope="module")
+def ddb_client() -> DynamoDBClient:
+    client: DynamoDBClient = session.client("dynamodb")
+    return client
+
+
+@pytest.fixture(scope="module")
+def s3_client() -> S3Client:
+    client: S3Client = session.client("s3")
+    return client
+
+
+@pytest.fixture(scope="module")
+def ssm_client() -> SSMClient:
+    client: SSMClient = session.client("ssm")
+    return client
+
+
+@pytest.fixture(scope="package")
+def eventbridge_client() -> EventBridgeClient:
+    client: EventBridgeClient = session.client("events")
+    return client
+
+
+@pytest.fixture(scope="package")
+def lambda_client() -> LambdaClient:
+    client: LambdaClient = session.client("lambda")
+    return client
+
+
+@pytest.fixture(scope="package")
+def logs_client() -> CloudWatchLogsClient:
+    client: CloudWatchLogsClient = session.client("logs")
+    return client
+
+
 @pytest.fixture(autouse=True, scope="package")
-def set_up_environment() -> Any:
+def set_up_environment(
+    lambda_client: LambdaClient, eventbridge_client: EventBridgeClient
+) -> Any:
     solution_stack_details = _get_stack_outputs(stack_name=os.environ["STACK_NAME"])
     assert "Outputs" in solution_stack_details
     _set_env_from_cfn_outputs(solution_stack_details["Outputs"])
@@ -44,17 +106,18 @@ def set_up_environment() -> Any:
     )
     assert "Outputs" in mock_sns_stack_details
     _set_env_from_cfn_outputs(mock_sns_stack_details["Outputs"])
-    _setup_mock_lambda_env()
-    _setup_lambda_permissions_to_invoke()
-    _setup_mock_sns_notify_lambda_permissions()
+    _setup_mock_lambda_env(lambda_client)
+    _setup_lambda_permissions_to_invoke(lambda_client)
+    _setup_mock_sns_notify_lambda_permissions(lambda_client)
     yield
-    _cleanup_mock_sns_notify_lambda_permissions()
-    _cleanup_lambda_permissions_to_invoke()
-    _cleanup_mock_lambda_env()
+    _cleanup_mock_sns_notify_lambda_permissions(lambda_client)
+    _cleanup_lambda_permissions_to_invoke(lambda_client)
+    _cleanup_mock_lambda_env(lambda_client)
+    _cleanup_eventbridge_targets(eventbridge_client)
 
 
 def _get_stack_outputs(stack_name: str) -> Dict:  # type: ignore
-    client: CloudFormationClient = boto3.client("cloudformation")
+    client: CloudFormationClient = session.client("cloudformation")
     return client.describe_stacks(StackName=stack_name)["Stacks"][0]  # type: ignore
 
 
@@ -63,7 +126,7 @@ def _set_env_from_cfn_outputs(cfn_outputs: List[Dict]) -> None:  # type: ignore
         os.environ[output["OutputKey"]] = output["OutputValue"]
 
 
-def _setup_mock_lambda_env() -> None:
+def _setup_mock_lambda_env(lambda_client: LambdaClient) -> None:
     for key in lambdas_to_update_env_variables:
         existing_env_variables = {}
         lambda_configuration = lambda_client.get_function_configuration(
@@ -86,7 +149,7 @@ def _setup_mock_lambda_env() -> None:
         )
 
 
-def _cleanup_mock_lambda_env() -> None:
+def _cleanup_mock_lambda_env(lambda_client: LambdaClient) -> None:
     for key in lambdas_to_update_env_variables:
         env_variables = {}
         lambda_configuration = lambda_client.get_function_configuration(
@@ -109,7 +172,7 @@ def _cleanup_mock_lambda_env() -> None:
         )
 
 
-def _setup_lambda_permissions_to_invoke() -> None:
+def _setup_lambda_permissions_to_invoke(lambda_client: LambdaClient) -> None:
     policy_document = json.dumps(
         {
             "Version": "2012-10-17",
@@ -128,17 +191,20 @@ def _setup_lambda_permissions_to_invoke() -> None:
             function_name=os.environ[key],
             policy_name="Invoke-MockNotifySNSLambda",
             policy_document=policy_document,
+            lambda_client=lambda_client,
         )
 
 
-def _cleanup_lambda_permissions_to_invoke() -> None:
+def _cleanup_lambda_permissions_to_invoke(lambda_client: LambdaClient) -> None:
     for key in lambdas_to_update_invoke_permissions:
         _remove_policy_from_lambda(
-            function_name=os.environ[key], policy_name="Invoke-MockNotifySNSLambda"
+            function_name=os.environ[key],
+            policy_name="Invoke-MockNotifySNSLambda",
+            lambda_client=lambda_client,
         )
 
 
-def _setup_mock_sns_notify_lambda_permissions() -> None:
+def _setup_mock_sns_notify_lambda_permissions(lambda_client: LambdaClient) -> None:
     policy_document = json.dumps(
         {
             "Version": "2012-10-17",
@@ -156,18 +222,38 @@ def _setup_mock_sns_notify_lambda_permissions() -> None:
         function_name=os.environ[OutputKeys.MOCK_NOTIFY_SNS_LAMBDA_ARN],
         policy_name="Publish-AsyncFacilitatorTopic",
         policy_document=policy_document,
+        lambda_client=lambda_client,
     )
 
 
-def _cleanup_mock_sns_notify_lambda_permissions() -> None:
+def _cleanup_mock_sns_notify_lambda_permissions(lambda_client: LambdaClient) -> None:
     _remove_policy_from_lambda(
         function_name=os.environ[OutputKeys.MOCK_NOTIFY_SNS_LAMBDA_ARN],
         policy_name="Publish-AsyncFacilitatorTopic",
+        lambda_client=lambda_client,
     )
 
 
+def _cleanup_eventbridge_targets(eventbridge_client: EventBridgeClient) -> None:
+    for rule in [
+        os.environ[OutputKeys.CLOUDWATCH_DASHBOARD_UPDATE_RULE_NAME],
+        os.environ[OutputKeys.WORKFLOW_COMPLETION_CHECKER_RULE_NAME],
+        os.environ[OutputKeys.EXTEND_DOWNLOAD_WINDOW_RULE_NAME],
+    ]:
+        response = eventbridge_client.list_targets_by_rule(Rule=rule)
+        ids = [target["Id"] for target in response["Targets"]]
+        if ids:
+            eventbridge_client.remove_targets(
+                Rule=rule,
+                Ids=[target["Id"] for target in response["Targets"]],
+            )
+
+
 def _put_policy_on_lambda(
-    function_name: str, policy_name: str, policy_document: str
+    function_name: str,
+    policy_name: str,
+    policy_document: str,
+    lambda_client: LambdaClient,
 ) -> None:
     function_configuration = lambda_client.get_function(FunctionName=function_name)
     if function_configuration and "Configuration" in function_configuration:
@@ -179,7 +265,9 @@ def _put_policy_on_lambda(
         )
 
 
-def _remove_policy_from_lambda(function_name: str, policy_name: str) -> None:
+def _remove_policy_from_lambda(
+    function_name: str, policy_name: str, lambda_client: LambdaClient
+) -> None:
     function_configuration = lambda_client.get_function(FunctionName=function_name)
     try:
         if function_configuration and "Configuration" in function_configuration:

--- a/source/tests/integration/infrastructure/test_archives_status_cleanup.py
+++ b/source/tests/integration/infrastructure/test_archives_status_cleanup.py
@@ -25,9 +25,10 @@ def default_input() -> str:
     return json.dumps({"workflow_run": WORKFLOW_RUN})
 
 
-def test_state_machine_start_execution(default_input: str) -> None:
-    client: SFNClient = boto3.client("stepfunctions")
-    response = client.start_execution(
+def test_state_machine_start_execution(
+    default_input: str, sfn_client: SFNClient
+) -> None:
+    response = sfn_client.start_execution(
         stateMachineArn=os.environ[
             OutputKeys.ARCHIVES_STATUS_CLEANUP_STATE_MACHINE_ARN
         ],

--- a/source/tests/integration/infrastructure/test_buckets.py
+++ b/source/tests/integration/infrastructure/test_buckets.py
@@ -16,23 +16,21 @@ else:
     S3Client = object
 
 
-def assert_bucket_put_get_object(bucket_name: str) -> None:
-    client: S3Client = boto3.client("s3")
-
+def assert_bucket_put_get_object(bucket_name: str, s3_client: S3Client) -> None:
     value = "test data".encode("utf-8")
     key = "test_object.txt"
-    client.put_object(Bucket=bucket_name, Key=key, Body=value)
+    s3_client.put_object(Bucket=bucket_name, Key=key, Body=value)
 
-    assert value == client.get_object(Bucket=bucket_name, Key=key)["Body"].read()
+    assert value == s3_client.get_object(Bucket=bucket_name, Key=key)["Body"].read()
 
-    client.delete_object(Bucket=bucket_name, Key=key)
+    s3_client.delete_object(Bucket=bucket_name, Key=key)
 
 
-def test_output_bucket_put_get_object() -> None:
+def test_output_bucket_put_get_object(s3_client: S3Client) -> None:
     bucket_name = os.environ[OutputKeys.OUTPUT_BUCKET_NAME]
-    assert_bucket_put_get_object(bucket_name)
+    assert_bucket_put_get_object(bucket_name, s3_client)
 
 
-def test_inventory_bucket_put_get_object() -> None:
+def test_inventory_bucket_put_get_object(s3_client: S3Client) -> None:
     bucket_name = os.environ[OutputKeys.INVENTORY_BUCKET_NAME]
-    assert_bucket_put_get_object(bucket_name)
+    assert_bucket_put_get_object(bucket_name, s3_client)

--- a/source/tests/integration/infrastructure/test_chunk_retrieval_lambda.py
+++ b/source/tests/integration/infrastructure/test_chunk_retrieval_lambda.py
@@ -16,15 +16,14 @@ else:
     LambdaClient = object
 
 
-def test_lambda_invoke() -> None:
+def test_lambda_invoke(lambda_client: LambdaClient) -> None:
     # ClientError exception will be thrown if the invocation of the Lambda function fails.
 
-    client: LambdaClient = boto3.client("lambda")
     lambda_name = os.environ[OutputKeys.CHUNK_RETRIEVAL_LAMBDA_ARN]
 
     test_event = ""
 
-    client.invoke(
+    lambda_client.invoke(
         FunctionName=lambda_name,
         InvocationType="RequestResponse",
         Payload=test_event,

--- a/source/tests/integration/infrastructure/test_cleanup_step_function.py
+++ b/source/tests/integration/infrastructure/test_cleanup_step_function.py
@@ -23,18 +23,6 @@ else:
 
 
 @pytest.fixture(scope="module")
-def s3_client() -> S3Client:
-    client: S3Client = boto3.client("s3")
-    return client
-
-
-@pytest.fixture(scope="module")
-def sfn_client() -> SFNClient:
-    client: SFNClient = boto3.client("stepfunctions")
-    return client
-
-
-@pytest.fixture(scope="module")
 def bucket() -> str:
     return os.environ[OutputKeys.OUTPUT_BUCKET_NAME]
 

--- a/source/tests/integration/infrastructure/test_cloudwatch_dashboard_update_step_function.py
+++ b/source/tests/integration/infrastructure/test_cloudwatch_dashboard_update_step_function.py
@@ -58,11 +58,6 @@ def setup() -> Any:
 
 
 @pytest.fixture(scope="module")
-def sfn_client() -> Any:
-    return boto3.client("stepfunctions")
-
-
-@pytest.fixture(scope="module")
 def sfn_execution_arn(default_input: str, sfn_client: SFNClient) -> Any:
     response = sfn_client.start_execution(
         stateMachineArn=os.environ[
@@ -82,9 +77,10 @@ def sf_history_output(sfn_client: SFNClient, sfn_execution_arn: str) -> Any:
     )
 
 
-def test_state_machine_start_execution(default_input: str) -> None:
-    client: SFNClient = boto3.client("stepfunctions")
-    response = client.start_execution(
+def test_state_machine_start_execution(
+    default_input: str, sfn_client: SFNClient
+) -> None:
+    response = sfn_client.start_execution(
         stateMachineArn=os.environ[
             OutputKeys.CLOUDWATCH_DASHBOARD_UPDATE_STATE_MACHINE_ARN
         ]

--- a/source/tests/integration/infrastructure/test_counter_query_definitions.py
+++ b/source/tests/integration/infrastructure/test_counter_query_definitions.py
@@ -1,0 +1,110 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import os
+import time
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, List
+
+from solution.infrastructure.output_keys import OutputKeys
+
+if TYPE_CHECKING:
+    from mypy_boto3_lambda import LambdaClient
+    from mypy_boto3_logs import CloudWatchLogsClient
+    from mypy_boto3_logs.type_defs import InputLogEventTypeDef
+else:
+    CloudWatchLogsClient = object
+    InputLogEventTypeDef = object
+    LambdaClient = object
+
+
+def create_log_stream_and_add_logs_entry(
+    logs_client: CloudWatchLogsClient,
+    workflow_id: str,
+    archives_count: int,
+    log_group_name: str,
+    log_stream_name: str,
+) -> None:
+    event_time = int(datetime.now().timestamp()) * 1000
+
+    response = logs_client.create_log_stream(
+        logGroupName=log_group_name, logStreamName=log_stream_name
+    )
+
+    log_entries: List[InputLogEventTypeDef] = []
+    for i in range(archives_count):
+        log_entries.append(
+            {
+                "timestamp": event_time,
+                "message": f"[INFO]	2020-01-01T01:01:01.001Z	7d95ff3b-23ac-408e-b215-98f903b28df{i}	Archive:{workflow_id}|test_archive_id_{i} - counted_status:downloaded",
+            }
+        )
+
+    response = logs_client.put_log_events(
+        logGroupName=log_group_name,
+        logStreamName=log_stream_name,
+        logEvents=log_entries,
+    )
+
+
+def test_downloaded_counter_query(
+    lambda_client: LambdaClient, logs_client: CloudWatchLogsClient
+) -> None:
+    lambda_client.invoke(
+        FunctionName=os.environ[OutputKeys.METRIC_UPDATE_LAMBDA_NAME],
+        InvocationType="RequestResponse",
+        Payload="",
+    )
+    # Add 20 secs delay to allow the creation of the logGroup
+    time.sleep(20)
+
+    response = logs_client.describe_query_definitions()
+    for query_definition in response["queryDefinitions"]:
+        if (
+            query_definition["name"]
+            == os.environ[OutputKeys.LOGS_INSIGHTS_DOWNLOADED_COUNTER_QUERY_NAME]
+        ):
+            timestamp = int(datetime.now().timestamp()) * 1000
+            log_group_name = str(query_definition["logGroupNames"][0])
+            log_stream_name = f"test_log_stream_{timestamp}"
+            workflow_id = f"test_workflow_id_{timestamp}"
+
+            archives_count = 5
+            create_log_stream_and_add_logs_entry(
+                logs_client,
+                workflow_id,
+                archives_count,
+                log_group_name,
+                log_stream_name,
+            )
+
+            # Add 3 mins delay to allow the logs events to be ingested into CloudWatch Logs
+            time.sleep(180)
+
+            query_response = logs_client.start_query(
+                logGroupNames=query_definition["logGroupNames"],
+                startTime=int((datetime.now() - timedelta(minutes=10)).timestamp())
+                * 1000,
+                endTime=int(datetime.now().timestamp()) * 1000,
+                queryString=query_definition["queryString"],
+                limit=100,
+            )
+
+            query_id = query_response["queryId"]
+
+            start_time = time.time()
+            while time.time() - start_time < 30:
+                query_status = logs_client.get_query_results(queryId=query_id)
+                if query_status["status"] == "Complete":
+                    break
+                time.sleep(1)
+
+            results = query_status["results"]
+
+            assert any(
+                result[0]["value"] == workflow_id
+                and result[1]["value"] == str(archives_count)
+                for result in results
+            )

--- a/source/tests/integration/infrastructure/test_inventory_chunk_determination_lambda.py
+++ b/source/tests/integration/infrastructure/test_inventory_chunk_determination_lambda.py
@@ -17,26 +17,26 @@ else:
     LambdaClient = object
 
 
-def test_lambda_invoke() -> None:
-    client: LambdaClient = boto3.client("lambda")
+def test_lambda_invoke(lambda_client: LambdaClient) -> None:
     lambda_name = os.environ[OutputKeys.INVENTORY_CHUNK_DETERMINATION_LAMBDA_ARN]
 
     test_event = '{"TotalSize": 100, "ChunkSize": 10}'
 
-    client.invoke(
+    lambda_client.invoke(
         FunctionName=lambda_name,
         InvocationType="RequestResponse",
         Payload=test_event,
     )
 
 
-def test_lambda_invoke_incomplete_parameters_request() -> None:
-    client: LambdaClient = boto3.client("lambda")
+def test_lambda_invoke_incomplete_parameters_request(
+    lambda_client: LambdaClient,
+) -> None:
     lambda_name = os.environ[OutputKeys.INVENTORY_CHUNK_DETERMINATION_LAMBDA_ARN]
 
     test_event = '{"InventorySize": 100}'
 
-    response = client.invoke(
+    response = lambda_client.invoke(
         FunctionName=lambda_name,
         InvocationType="RequestResponse",
         Payload=test_event,

--- a/source/tests/integration/infrastructure/test_orchestrator_step_function.py
+++ b/source/tests/integration/infrastructure/test_orchestrator_step_function.py
@@ -61,9 +61,10 @@ def setup() -> Any:
     s3_util.delete_archives_from_s3(prefix=WORKFLOW_RUN)
 
 
-def test_state_machine_start_execution(default_input: str) -> None:
-    client: SFNClient = boto3.client("stepfunctions")
-    response = client.start_execution(
+def test_state_machine_start_execution(
+    default_input: str, sfn_client: SFNClient
+) -> None:
+    response = sfn_client.start_execution(
         stateMachineArn=os.environ[OutputKeys.ORCHESTRATOR_STATE_MACHINE_ARN],
         input=default_input,
     )

--- a/source/tests/integration/infrastructure/test_system_manager.py
+++ b/source/tests/integration/infrastructure/test_system_manager.py
@@ -24,12 +24,6 @@ else:
 
 
 @pytest.fixture(scope="module")
-def ssm_client() -> SSMClient:
-    ssm_client: SSMClient = boto3.client("ssm")
-    return ssm_client
-
-
-@pytest.fixture(scope="module")
 def default_input() -> Dict[str, Any]:
     return {
         "ProvidedInventory": [
@@ -37,6 +31,9 @@ def default_input() -> Dict[str, Any]:
         ],
         "VaultName": [
             "test_medium_vault",
+        ],
+        "AcknowledgeAdditionalCostForCrossRegionTransfer": [
+            "YES",
         ],
     }
 

--- a/source/tests/integration/infrastructure/util/ssm_util.py
+++ b/source/tests/integration/infrastructure/util/ssm_util.py
@@ -3,6 +3,7 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import os
 import time
 from typing import TYPE_CHECKING
 
@@ -14,11 +15,24 @@ else:
     SSMClient = object
 
 
+def ssm_client() -> SSMClient:
+    if "AWS_PROFILE" in os.environ and "AWS_REGION" in os.environ:
+        session = boto3.Session(
+            profile_name=os.environ["AWS_PROFILE"],
+            region_name=os.environ["AWS_REGION"],
+        )
+    else:
+        session = boto3.Session()
+
+    client: SSMClient = session.client("ssm")
+    return client
+
+
 def poll_execution_status(execution_id: str) -> str:
-    ssm_client: SSMClient = boto3.client("ssm")
+    client: SSMClient = ssm_client()
     start_time = time.time()
     while (time.time() - start_time) < 90:
-        automation_response = ssm_client.get_automation_execution(
+        automation_response = client.get_automation_execution(
             AutomationExecutionId=execution_id
         )
         if automation_response["AutomationExecution"]["AutomationExecutionStatus"] in [

--- a/source/tests/unit/application/archive_naming/test_override.py
+++ b/source/tests/unit/application/archive_naming/test_override.py
@@ -9,14 +9,18 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
+from botocore.config import Config
 
 if TYPE_CHECKING:
     from mypy_boto3_s3.client import S3Client
 else:
     S3Client = object
 
-
-from solution.application.archive_naming.override import upload_provided_file
+from solution.application import __boto_config__
+from solution.application.archive_naming.override import (
+    create_header_file,
+    upload_provided_file,
+)
 from solution.infrastructure.output_keys import OutputKeys
 
 
@@ -28,16 +32,42 @@ def mock_inventory_bucket(s3_client: S3Client) -> None:
     s3_client.create_bucket(Bucket=os.environ[OutputKeys.INVENTORY_BUCKET_NAME])
 
 
-def test_upload_provided_file_successful(s3_client: S3Client) -> None:
-    workflow_run = "test-workflow_run"
-    presigned_url = "https://test_url.test/mock-presigned-url"
+@pytest.fixture()
+def workflow_run() -> str:
+    return "test-workflow_run"
 
+
+@pytest.fixture()
+def pre_signed_url() -> str:
+    return "https://test_url.test/mock-presigned-url"
+
+
+def test_user_agent_on_s3_client(
+    solution_user_agent: str,
+    workflow_run: str,
+    pre_signed_url: str,
+) -> None:
+    with patch("boto3.client") as mock_client:
+        create_header_file(workflow_run)
+        _config = mock_client.call_args[1]["config"]
+        assert type(_config) is Config
+
+        _config_user_agent_extra = _config.__getattribute__("user_agent_extra")
+        assert _config_user_agent_extra == __boto_config__.__getattribute__(
+            "user_agent_extra"
+        )
+        assert _config_user_agent_extra == solution_user_agent
+
+
+def test_upload_provided_file_successful(
+    s3_client: S3Client, workflow_run: str, pre_signed_url: str
+) -> None:
     content = b"Mock content"
     with patch("urllib.request.urlopen") as mock_urlopen:
         mock_urlopen.return_value.__enter__().getcode.return_value = 200
         mock_urlopen.return_value.__enter__().read.return_value = content
 
-        upload_provided_file(workflow_run, presigned_url)
+        upload_provided_file(workflow_run, pre_signed_url)
 
     obj = s3_client.get_object(
         Bucket=os.environ[OutputKeys.INVENTORY_BUCKET_NAME],
@@ -46,14 +76,13 @@ def test_upload_provided_file_successful(s3_client: S3Client) -> None:
     assert content == obj["Body"].read()
 
 
-def test_upload_provided_file_expired_url(s3_client: S3Client) -> None:
-    workflow_run = "test-workflow_run"
-    presigned_url = "https://test_url.test/mock-presigned-url"
-
+def test_upload_provided_file_expired_url(
+    s3_client: S3Client, workflow_run: str, pre_signed_url: str
+) -> None:
     mock_exception = urllib.error.HTTPError(
-        presigned_url, 403, "Forbidden", {}, None  # type:ignore
+        pre_signed_url, 403, "Forbidden", {}, None  # type:ignore
     )
 
     with patch("urllib.request.urlopen", side_effect=mock_exception) as mock_urlopen:
         with pytest.raises(Exception):
-            upload_provided_file(workflow_run, presigned_url)
+            upload_provided_file(workflow_run, pre_signed_url)

--- a/source/tests/unit/application/completion/test_checker.py
+++ b/source/tests/unit/application/completion/test_checker.py
@@ -4,13 +4,19 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import os
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import Any, Dict, Optional
+from unittest.mock import Mock, patch
 
 import pytest
+from botocore.config import Config
 from mypy_boto3_dynamodb import DynamoDBClient
 from mypy_boto3_dynamodb.type_defs import CreateTableOutputTypeDef, PutItemOutputTypeDef
 
-from solution.application.completion.checker import is_workflow_completed
+from solution.application import __boto_config__
+from solution.application.completion.checker import (
+    check_workflow_completion,
+    is_workflow_completed,
+)
 from solution.application.model.metric_record import MetricRecord
 from solution.infrastructure.output_keys import OutputKeys
 
@@ -31,8 +37,7 @@ def test_is_workflow_completed(
     metric_table_mock: CreateTableOutputTypeDef,
     dynamodb_client: DynamoDBClient,
 ) -> None:
-    base_item: Dict[str, Any] = {"count_total": 2}
-    base_item["pk"] = workflow_run
+    base_item: Dict[str, Any] = {"count_total": 2, "pk": workflow_run}
     if count_downloaded:
         base_item["count_downloaded"] = count_downloaded
 
@@ -50,3 +55,23 @@ def metric_table_put_item(
     return dynamodb_client.put_item(
         TableName=os.environ[OutputKeys.METRIC_TABLE_NAME], Item=metric_record.marshal()
     )
+
+
+@patch(
+    "solution.application.completion.checker.is_workflow_completed", return_value=None
+)
+def test_user_agent_on_dynamodb_client(
+    _is_workflow_completed_mock: Mock,
+    solution_user_agent: str,
+) -> None:
+    with patch("boto3.client") as mock_client:
+        check_workflow_completion("test_workflow_run")
+
+        _config = mock_client.call_args[1]["config"]
+        assert type(_config) is Config
+
+        _config_user_agent_extra = _config.__getattribute__("user_agent_extra")
+        assert _config_user_agent_extra == __boto_config__.__getattribute__(
+            "user_agent_extra"
+        )
+        assert _config_user_agent_extra == solution_user_agent

--- a/source/tests/unit/application/db_accessor/test_db_accessor.py
+++ b/source/tests/unit/application/db_accessor/test_db_accessor.py
@@ -8,7 +8,9 @@ import os
 from typing import TYPE_CHECKING, Dict, Tuple
 
 import pytest
+from botocore.config import Config
 
+from solution.application import __boto_config__
 from solution.application.db_accessor.dynamoDb_accessor import DynamoDBAccessor
 from solution.infrastructure.output_keys import OutputKeys
 
@@ -114,3 +116,19 @@ def test_query_items(
     expected_items = [ddb_table_item]
     result = dynamodb_accessor_mock.query_items("job_id = :key", {":key": {"S": "123"}})
     assert result == expected_items
+
+
+def test_user_agent_on_dynamodb_client(
+    solution_user_agent: str,
+    dynamodb_client: DynamoDBClient,
+) -> None:
+    ddb_accessor = DynamoDBAccessor("")
+
+    _config = ddb_accessor.dynamodb.meta.config
+    assert type(_config) is Config
+
+    _config_user_agent_extra = _config.__getattribute__("user_agent_extra")
+    assert _config_user_agent_extra == __boto_config__.__getattribute__(
+        "user_agent_extra"
+    )
+    assert _config_user_agent_extra == solution_user_agent

--- a/source/tests/unit/application/glacier_service/test_glacier_api_factory.py
+++ b/source/tests/unit/application/glacier_service/test_glacier_api_factory.py
@@ -1,0 +1,25 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from typing import Iterator
+
+from botocore.config import Config
+from mypy_boto3_glacier import GlacierClient
+
+from solution.application import __boto_config__
+from solution.application.glacier_service.glacier_apis_factory import GlacierAPIsFactory
+
+
+def test_user_agent_on_glacier_client(
+    glacier_client: Iterator[GlacierClient], solution_user_agent: str
+) -> None:
+    _client = GlacierAPIsFactory.create_instance()
+    _config = _client.meta.config
+    assert type(_config) is Config
+    _config_user_agent_extra = _config.__getattribute__("user_agent_extra")
+    assert _config_user_agent_extra == __boto_config__.__getattribute__(
+        "user_agent_extra"
+    )
+    assert _config_user_agent_extra == solution_user_agent

--- a/source/tests/unit/conftest.py
+++ b/source/tests/unit/conftest.py
@@ -3,6 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 """
 
+
+import logging
 import os
 from typing import TYPE_CHECKING, Any, Dict, Generator, Iterator, Tuple
 
@@ -11,6 +13,7 @@ import aws_cdk.assertions as assertions
 import boto3
 import cdk_nag
 import pytest
+from botocore.config import Config
 from moto import mock_dynamodb, mock_glacier, mock_s3, mock_sqs  # type: ignore
 from mypy_boto3_dynamodb import DynamoDBClient
 from mypy_boto3_dynamodb.type_defs import CreateTableOutputTypeDef
@@ -23,9 +26,10 @@ from solution.infrastructure.output_keys import OutputKeys
 from solution.infrastructure.stack import SolutionStack
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module", autouse=True)
 def aws_credentials() -> None:
     """Mocked AWS Credentials for moto"""
+    os.environ["AWS_ACCOUNT_ID"] = "testing"
     os.environ["AWS_ACCESS_KEY_ID"] = "testing"
     os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
     os.environ["AWS_SECURITY_TOKEN"] = "testing"
@@ -40,6 +44,12 @@ def aws_credentials() -> None:
     os.environ[OutputKeys.GLACIER_RETRIEVAL_INDEX_NAME] = "staged_archives_index"
     os.environ[OutputKeys.METRIC_TABLE_NAME] = "MetricTable"
     os.environ[OutputKeys.VALIDATION_SQS_URL] = "ValidationSQS"
+    os.environ["LOGGING_LEVEL"] = str(logging.INFO)
+
+
+@pytest.fixture(scope="module")
+def solution_user_agent() -> str:
+    return "AwsSolution/SO0293/v1.1.0"
 
 
 @pytest.fixture(scope="module")

--- a/source/tests/unit/infrastructure/glue_helper/test_glue_sfn_update.py
+++ b/source/tests/unit/infrastructure/glue_helper/test_glue_sfn_update.py
@@ -285,3 +285,9 @@ def test_start_job(glue_sfn_update: GlueSfnUpdate) -> None:
     state_json = task.to_state_json()
     assert isinstance(task, GlueStartJobRun)
     assert state_json["Parameters"]["JobName"] == "test-job"
+    assert state_json["Parameters"]["Arguments"]["--enable-job-insights"] == "true"
+    assert (
+        state_json["Parameters"]["Arguments"]["--enable-continuous-cloudwatch-log"]
+        == "true"
+    )
+    assert state_json["Parameters"]["Arguments"]["--job-language"] == "python"

--- a/source/tests/unit/infrastructure/ssm_automation_docs/scripts/test_orchestration_doc_script.py
+++ b/source/tests/unit/infrastructure/ssm_automation_docs/scripts/test_orchestration_doc_script.py
@@ -11,8 +11,14 @@ import pytest
 from mypy_boto3_dynamodb import DynamoDBClient
 
 from solution.infrastructure.ssm_automation_docs.scripts.orchestration_doc_script import (
+    check_cross_region_transfer,
     script_handler,
 )
+
+
+@pytest.fixture
+def solution_name() -> str:
+    return "Data-Retrieval-for-Glacier-S3"
 
 
 def test_script_handler_launch_automation() -> None:
@@ -40,9 +46,18 @@ def test_script_handler_launch_automation() -> None:
             "migration_type": "LAUNCH",
             "name_override_presigned_url": None,
             "vault_name": "test_vault",
+            "acknowledge_cross_region": "YES",
+            "bucket_name": "test_bucket_name",
+            "region": "us-east-1",
+            "allow_cross_region_data_transfer": True,
         }
 
         script_handler(events, None)  # type: ignore
+
+        events.pop("acknowledge_cross_region")
+        events.pop("bucket_name")
+        events.pop("region")
+        events.pop("allow_cross_region_data_transfer")
 
         events["s3_storage_class"] = "GLACIER_IR"
 
@@ -106,12 +121,69 @@ def test_script_handler_resume_automation(
             "migration_type": "RESUME",
             "table_name": glacier_retrieval_table_mock[1],
             "name_override_presigned_url": None,
+            "acknowledge_cross_region": "YES",
+            "bucket_name": "test_bucket_name",
+            "region": "us-east-1",
+            "allow_cross_region_data_transfer": True,
         }
         script_handler(events, None)  # type: ignore
         events.pop("table_name")
+        events.pop("acknowledge_cross_region")
+        events.pop("bucket_name")
+        events.pop("region")
+        events.pop("allow_cross_region_data_transfer")
+
         events["s3_storage_class"] = "GLACIER_IR"
         events["vault_name"] = "test_vault_name"
         # assert that the start_execution method was called with the correct arguments
         mock_sf.start_execution.assert_called_once_with(
             stateMachineArn=events.pop("state_machine_arn"), input=json.dumps(events)
         )
+
+
+def test_check_cross_region_acknowledgement_NO_same_region() -> None:
+    with mock.patch("boto3.client") as mock_client:
+        mock_client_instance = mock_client.return_value
+        mock_client_instance.get_bucket_location.return_value = {
+            "LocationConstraint": "test_region"
+        }
+        check_cross_region_transfer(False, "NO", "test_bucket", "test_region")
+
+
+def test_check_cross_region_acknowledgement_NO_cross_region() -> None:
+    with mock.patch("boto3.client") as mock_client:
+        mock_client_instance = mock_client.return_value
+        mock_client_instance.get_bucket_location.return_value = {
+            "LocationConstraint": "test_region_1"
+        }
+        with pytest.raises(ValueError) as exc:
+            check_cross_region_transfer(False, "NO", "test_bucket", "test_region_2")
+
+
+def test_check_cross_region_acknowledgement_YES_default_deployment() -> None:
+    with mock.patch("boto3.client") as mock_client:
+        mock_client_instance = mock_client.return_value
+        mock_client_instance.get_bucket_location.return_value = {
+            "LocationConstraint": "test_region_1"
+        }
+        with pytest.raises(ValueError) as exc:
+            check_cross_region_transfer(False, "YES", "test_bucket", "test_region_2")
+
+
+def test_check_cross_region_acknowledgement_YES_modified_deployment() -> None:
+    with mock.patch("boto3.client") as mock_client:
+        mock_client_instance = mock_client.return_value
+        mock_client_instance.get_bucket_location.return_value = {
+            "LocationConstraint": "test_region_1"
+        }
+        check_cross_region_transfer(True, "YES", "test_bucket", "test_region_2")
+
+
+def test_check_cross_region_acknowledgement_NO_modified_deployment() -> None:
+    with mock.patch("boto3.client") as mock_client:
+        mock_client_instance = mock_client.return_value
+        mock_client_instance.get_bucket_location.return_value = {
+            "LocationConstraint": "test_region_1"
+        }
+        with pytest.raises(ValueError) as exc:
+            check_cross_region_transfer(True, "NO", "test_bucket", "test_region_2")

--- a/source/tests/unit/infrastructure/ssm_automation_docs/test_orchestration_automation_document.py
+++ b/source/tests/unit/infrastructure/ssm_automation_docs/test_orchestration_automation_document.py
@@ -17,7 +17,9 @@ def test_launch_yaml_doc() -> None:
     with mock.patch(
         "builtins.open", mock.mock_open(read_data="def func_name(): pass")
     ) as mock_open:
-        doc = LaunchAutomationDocument("ssm_role", "topic_arn", "state_machine_arn")
+        doc = LaunchAutomationDocument(
+            "ssm_role", "topic_arn", "state_machine_arn", "region", "bucket_name", True
+        )
         # create an instance of the class
 
         # assert that the _extract_func_name method was called
@@ -34,7 +36,13 @@ def test_resume_yaml_doc() -> None:
         "builtins.open", mock.mock_open(read_data="def func_name(): pass")
     ) as mock_open:
         doc = ResumeAutomationDocument(
-            "ssm_role", "topic_arn", "state_machine_arn", "table_name"
+            "ssm_role",
+            "topic_arn",
+            "state_machine_arn",
+            "table_name",
+            "region",
+            "bucket_name",
+            True,
         )
         # create an instance of the class
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,9 @@ minversion = 4.0.13
 description = run lint checks
 skip_install = true
 deps =
-    isort
-    black
-    pytest
+    isort==5.13.2
+    black==23.12.1
+    pytest==7.4.3
     moto==4.1.10
 commands =
     isort --check source


### PR DESCRIPTION
## Release 1.1.0

### Added

- Allow referencing an external destination bucket.
- Add SQS metrics widgets to CloudWatch dashboard to have a way to monitor the progress of the transfer
- Add a pre-built CloudWatch Logs Insights query for Lambdas errors

### Updated

- Implement retry within MetricsProcessor Lambda when encountering TransactionConflict exception
- Use SHA-256 to generate TransactWriteItems ClientRequestToken as a more secure alternative to MD5 hashing
- Add try-except block around the archive naming logic to prevent the entire Glue job from failing due to a single/few names parsing errors.
- Enhance SSM Automation documents descriptions
- Add user-agents to all service clients to track usage on solution service API usage dashboard

### Fixed

- Fix Glue jobs that are not generating CloudWatch logs
- Fix Glue job failures occurring when description fields contain UTF-8 encoded characters
- Fix duplicate archive names when there are identical archive names with the same creation time

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
