### PR TITLE
fix: Parse ArchiveDescription JSON

### DIFF
--- a/source/solution/infrastructure/glue_helper/scripts/archive_naming.py
+++ b/source/solution/infrastructure/glue_helper/scripts/archive_naming.py
@@ -47,7 +47,7 @@ def parse_description(archive_description: str) -> str:
     if re.search(r"{\s*\\*\".*}\s*", archive_description):
         try:
             json_object = json.loads(archive_description)
-            path = json_object.get("Path")
+            path = json_object.get("Path") or json_object.get("path")
             if isinstance(path, str):
                 return path
         except Exception as _:

--- a/source/tests/unit/infrastructure/glue_helper/scripts/test_archive_naming.py
+++ b/source/tests/unit/infrastructure/glue_helper/scripts/test_archive_naming.py
@@ -67,6 +67,22 @@ def test_empty_file_name_from_json() -> None:
     )
 
 
+def test_cloudberry_json_format_lowercase() -> None:
+    assert (
+        parse_description(
+            '{"path":"CB+F8-M5/B:/c01/q004/s0010/c01+AF8-s00+A8-s0010+F8/h01.1094.dpx","UTCDateModified":"20100310T110623Z"}'
+        )
+        == "CB+F8-M5/B:/c01/q004/s0010/c01+AF8-s00+A8-s0010+F8/h01.1094.dpx"
+    )
+
+
+def test_empty_file_name_from_json_lowercase() -> None:
+    assert (
+        parse_filename("AAAQQQ", '{"path":"   ","UTCDateModified":"20100310T110623Z"}')
+        == "00undefined/AAAQQQ"
+    )
+
+
 def test_empty_archive_description() -> None:
     assert parse_filename("AAAQQQ", "             ") == "00undefined/AAAQQQ"
 


### PR DESCRIPTION
*Description of changes:*

I found an issue where some files from the inventory weren't migrated from Glacier Vault to S3. I discovered that the files not migrated have an `ArchiveDescription` field containing the `path` (lowercase). Since Python's dictionary get method is case-sensitive, you need to explicitly check for both uppercase and lowercase possibilities.

Example from Glacier inventory with `path` (lowercases)
```
    {
      "ArchiveId": "[REDACTED]",
      "ArchiveDescription": "{\"path\": \"[REDACTED]", \"type\": \"file\"}",
      "CreationDate": "2019-07-27T08:34:34Z",
      "Size": 4454480,
      "SHA256TreeHash": "[REDACTED]"
    },
```

Example from Glacier inventory with `Path` (Capital letter)
```
    {
      "ArchiveId": "[REDACTED]",
      "ArchiveDescription": "{\"Path\": \"[REDACTED]", \"UTCDateModified\": \"2019-10-02T17:45:43Z\"}",
      "CreationDate": "2019-10-02T17:45:43Z",
      "Size": 6804112,
      "SHA256TreeHash": "[REDACTED]"
    },
```