### PR TITLE
Add support for cross-account migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Cross-account Glacier vault migration support via `SourceVaultAccountIdParameter`
+- Glue job `defusedxml` dependency resolution for archive naming
+
 ## [1.1.4] - 2024-11-20
 
 ### BREAKING CHANGES

--- a/README.md
+++ b/README.md
@@ -157,13 +157,15 @@ NOTE: The vault access policy is additive — it grants cross-account access wit
 
 ##### 2. Deploy the solution with the source vault account ID
 
-Pass the `SourceVaultAccountIdParameter` during deployment:
+Make sure "solution" is your project name, i.e. "data-transfer-from-amazon-s3-glacier-vaults-to-amazon-s3". Pass the `SourceVaultAccountIdParameter` and `DestinationBucketParameter` during deployment:
 
     npx cdk deploy solution \
       --parameters DestinationBucketParameter=my-output-bucket-name \
       --parameters SourceVaultAccountIdParameter=123456789012
 
 Replace `123456789012` with the 12-digit AWS account ID that owns the source Glacier vault.
+
+Replace `my-output-bucket-name' with the name of the destination S3 bucket.
 
 When `SourceVaultAccountIdParameter` is left empty (the default), the solution behaves identically to a same-account transfer.
 

--- a/README.md
+++ b/README.md
@@ -126,13 +126,52 @@ npx cdk bootstrap
     aws cloudformation describe-stacks --stack-name CDKToolkit --query "Stacks[0].Outputs[?OutputKey=='BucketName'].OutputValue" --output text`
 
 
+<details>
+<summary><strong>Same-account deployment</strong> — Glacier vault and S3 bucket are in the same AWS account</summary>
 
-   Deploy the Guidance
-   Make sure "solution" is your project name, i.e. "data-transfer-from-amazon-s3-glacier-vaults-to-amazon-s3", and DestinationBucketParameter are your newly created bucket
-
+Deploy the Guidance. Make sure "solution" is your project name, i.e. "data-transfer-from-amazon-s3-glacier-vaults-to-amazon-s3", and DestinationBucketParameter is your newly created bucket.
 
     npx cdk deploy solution --parameters DestinationBucketParameter=my-output-bucket-name
 
+Once deployed, initiate the transfer using the Systems Manager Launch document.
+
+</details>
+
+<details>
+<summary><strong>Cross-account deployment</strong> — Glacier vault is in a different AWS account than the destination S3 bucket</summary>
+
+The Guidance supports migrating archives from a Glacier vault in a different AWS account. Deploy the solution in the same account as the destination S3 bucket and provide the source vault's account ID as a CloudFormation parameter during deployment.
+
+##### 1. Set a vault access policy on the source vault
+
+In the account that owns the Glacier vault, set a vault access policy to allow the destination account to access it:
+
+    aws glacier set-vault-access-policy \
+      --account-id <SOURCE_ACCOUNT_ID> \
+      --vault-name <VAULT_NAME> \
+      --policy 'Policy="{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::<DESTINATION_ACCOUNT_ID>:root\"},\"Action\":[\"glacier:InitiateJob\",\"glacier:GetJobOutput\"],\"Resource\":\"arn:aws:glacier:<REGION>:<SOURCE_ACCOUNT_ID>:vaults/<VAULT_NAME>\"}]}"'
+
+Replace `<DESTINATION_ACCOUNT_ID>`, `<SOURCE_ACCOUNT_ID>`, `<REGION>`, and `<VAULT_NAME>` with your values. This command must be run by a principal in the source vault account with `glacier:SetVaultAccessPolicy` permission.
+
+NOTE: The vault access policy is additive — it grants cross-account access without affecting existing access from within the source account.
+
+##### 2. Deploy the solution with the source vault account ID
+
+Pass the `SourceVaultAccountIdParameter` during deployment:
+
+    npx cdk deploy solution \
+      --parameters DestinationBucketParameter=my-output-bucket-name \
+      --parameters SourceVaultAccountIdParameter=123456789012
+
+Replace `123456789012` with the 12-digit AWS account ID that owns the source Glacier vault.
+
+When `SourceVaultAccountIdParameter` is left empty (the default), the solution behaves identically to a same-account transfer.
+
+##### 3. Run the transfer
+
+Once both the vault policy and deployment are in place, initiate the transfer using the Systems Manager Launch document. The vault name refers to the vault in the source account.
+
+</details>
 
 NOTE: set context parameter `skip_integration_tests` to `false` to indicate if you want to run integration tests against the solution stack: `npx cdk deploy solution -c skip_integration_tests=false --parameters DestinationBucketParameter=my-output-bucket-name`._
 

--- a/source/solution/application/archive_retrieval/initiator.py
+++ b/source/solution/application/archive_retrieval/initiator.py
@@ -222,6 +222,7 @@ def initiate_request(
         file_name=archive["Filename"] or archive_id,
         s3_storage_class=s3_storage_class,
         description=archive["ArchiveDescription"],
+        vault_account_id=account_id,
     )
     put_glacier_transfer_metadata(archive_metadata.marshal(), ddb_client)
 

--- a/source/solution/application/archive_retrieval/notification_processor.py
+++ b/source/solution/application/archive_retrieval/notification_processor.py
@@ -75,6 +75,7 @@ def handle_archive_job_notification(message_str: str) -> None:
     file_name = glacier_transfer_record.file_name
     storage_class = glacier_transfer_record.s3_storage_class
     vault_name = glacier_transfer_record.vault_name
+    vault_account_id = glacier_transfer_record.vault_account_id or os.environ.get("AWS_ACCOUNT_ID", "-")
     object_key = f"{workflow_run}/{file_name}"
 
     logging.info(
@@ -110,6 +111,7 @@ def handle_archive_job_notification(message_str: str) -> None:
         archive_id,
         upload_id,
         object_key,
+        vault_account_id,
     )
 
 
@@ -150,6 +152,7 @@ def send_chunk_events(
     archive_id: str,
     upload_id: str,
     object_key: str,
+    vault_account_id: str,
 ) -> None:
     chunk_sqs_url = os.environ[OutputKeys.CHUNKS_SQS_URL]
     bucket_name = os.environ[OutputKeys.OUTPUT_BUCKET_NAME]
@@ -165,6 +168,7 @@ def send_chunk_events(
             "UploadId": upload_id,
             "PartNumber": index + 1,
             "WorkflowRun": workflow_run,
+            "VaultAccountId": vault_account_id,
         }
         sqs.send_message(QueueUrl=chunk_sqs_url, MessageBody=json.dumps(message_body))
 

--- a/source/solution/application/glacier_s3_transfer/download.py
+++ b/source/solution/application/glacier_s3_transfer/download.py
@@ -22,11 +22,13 @@ class GlacierDownload:
         job_id: str,
         vault_name: str,
         byte_range: str,
+        account_id: str = "-",
     ) -> None:
         self.params = {
             "jobId": job_id,
             "range": f"bytes={byte_range}",
             "vaultName": vault_name,
+            "accountId": account_id,
         }
         self.response: GetJobOutputOutputTypeDef = glacier_client.get_job_output(
             **self.params

--- a/source/solution/application/glacier_s3_transfer/facilitator.py
+++ b/source/solution/application/glacier_s3_transfer/facilitator.py
@@ -62,12 +62,14 @@ class GlacierToS3Facilitator:
         upload_id: str,
         part_number: int,
         glacier_job_type: str,
+        account_id: str = "-",
     ) -> None:
         self.glacier_client = glacier_client
         self.vault_name = vault_name
         self.workflow_run = workflow_run
         self.byte_range = byte_range
         self.glacier_object_id = glacier_object_id
+        self.account_id = account_id
 
         self.s3_destination_bucket = s3_destination_bucket
         self.s3_destination_key = s3_destination_key
@@ -121,6 +123,7 @@ class GlacierToS3Facilitator:
                 job_id,
                 self.vault_name,
                 self.byte_range,
+                self.account_id,
             )
             chunk = download.read()
         except self.glacier_client.exceptions.ResourceNotFoundException:

--- a/source/solution/application/handlers.py
+++ b/source/solution/application/handlers.py
@@ -126,6 +126,7 @@ def archive_retrieval(event: dict[str, Any], _context: Any) -> None:
                 upload_id=body["UploadId"],
                 part_number=body["PartNumber"],
                 glacier_job_type=GlacierJobType.ARCHIVE_RETRIEVAL,
+                account_id=body.get("VaultAccountId", "-"),
             )
             if facilitator.transfer():
                 facilitator.send_validation_event()
@@ -173,6 +174,7 @@ def inventory_retrieval(
         upload_id=event["UploadId"],
         part_number=event["PartNumber"],
         glacier_job_type=GlacierJobType.INVENTORY_RETRIEVAL,
+        account_id=event.get("VaultAccountId", "-"),
     )
     return facilitator.transfer()
 

--- a/source/solution/application/model/events.py
+++ b/source/solution/application/model/events.py
@@ -11,7 +11,7 @@ else:
     InitiateJobInputRequestTypeDef = TypedDict("MockType")
 
 
-class GlacierRetrieval(TypedDict):
+class _GlacierRetrievalRequired(TypedDict):
     JobId: str
     VaultName: str
     ByteRange: str
@@ -21,6 +21,10 @@ class GlacierRetrieval(TypedDict):
     UploadId: str
     PartNumber: int
     WorkflowRun: str
+
+
+class GlacierRetrieval(_GlacierRetrievalRequired, total=False):
+    VaultAccountId: str
 
 
 class InventoryChunkOverlap(TypedDict):

--- a/source/solution/application/model/glacier_transfer_meta_model.py
+++ b/source/solution/application/model/glacier_transfer_meta_model.py
@@ -46,3 +46,6 @@ class GlacierTransferMetadata(GlacierTransferMetadataRead):
     s3_destination_key: str | None = Model.field(
         ["s3_destination_key", "S"], optional=True
     )
+    vault_account_id: str | None = Model.field(
+        ["vault_account_id", "S"], optional=True
+    )

--- a/source/solution/infrastructure/glue_helper/glue_sfn_update.py
+++ b/source/solution/infrastructure/glue_helper/glue_sfn_update.py
@@ -430,6 +430,7 @@ class GlueSfnUpdate(object):
                     "--enable-job-insights": "true",
                     "--enable-continuous-cloudwatch-log": "true",
                     "--job-language": "python",
+                    "--additional-python-modules": "defusedxml",
                 }
             ),
             result_path="$.glue_start_job_result",

--- a/source/solution/infrastructure/stack.py
+++ b/source/solution/infrastructure/stack.py
@@ -211,7 +211,7 @@ class SolutionStack(Stack):
             self,
             "DestinationBucketParameter",
             type="String",
-            description="(Required) The destination Amazon S3 bucket name. The destination Amazon S3 bucket must be in the same AWS account as the Glacier vault, cross-account transfers are not supported.",
+            description="(Required) The destination Amazon S3 bucket name.",
             allowed_pattern="(?!(^xn--|^sthree-|.+-s3alias$|.+--ol-s3$))^[a-zA-Z0-9][a-zA-Z0-9-._]{1,253}[a-zA-Z0-9]$",
         )
 
@@ -219,6 +219,26 @@ class SolutionStack(Stack):
             stack_info.parameters.destination_bucket_parameter.default = (
                 output_bucket_name_context
             )
+
+        stack_info.parameters.source_vault_account_id_parameter = CfnParameter(
+            self,
+            "SourceVaultAccountIdParameter",
+            type="String",
+            description="(Optional) The AWS account ID that owns the source Glacier vault. Defaults to the current account. Set this to enable cross-account vault access.",
+            default="",
+            allowed_pattern="^[0-9]{12}$|^$",
+        )
+
+        stack_info.cfn_conditions.is_cross_account_vault_condition = CfnCondition(
+            self,
+            "IsCrossAccountVaultCondition",
+            expression=Fn.condition_not(
+                Fn.condition_equals(
+                    stack_info.parameters.source_vault_account_id_parameter.value_as_string,
+                    "",
+                )
+            ),
+        )
 
         stack_info.parameters.enable_ddb_backup_parameter = CfnParameter(
             self,
@@ -337,7 +357,15 @@ class SolutionStack(Stack):
                 principals=[
                     iam.ServicePrincipal("glacier.amazonaws.com"),
                 ],
-                conditions={"StringEquals": {"AWS:SourceOwner": Aws.ACCOUNT_ID}},
+                conditions={
+                    "StringEquals": {
+                        "AWS:SourceOwner": Fn.condition_if(
+                            stack_info.cfn_conditions.is_cross_account_vault_condition.logical_id,
+                            stack_info.parameters.source_vault_account_id_parameter.value_as_string,
+                            Aws.ACCOUNT_ID,
+                        ),
+                    }
+                },
             )
         )
 

--- a/source/solution/infrastructure/workflows/extend_download_window.py
+++ b/source/solution/infrastructure/workflows/extend_download_window.py
@@ -3,7 +3,7 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from aws_cdk import Aws, CfnElement, CfnOutput, Duration, Stack
+from aws_cdk import Aws, CfnElement, CfnOutput, Duration, Fn, Stack
 from aws_cdk import aws_dynamodb as dynamodb
 from aws_cdk import aws_events as eventbridge
 from aws_cdk import aws_iam as iam
@@ -133,6 +133,12 @@ class Workflow:
             value=stack_info.lambdas.extend_download_window_initiate_retrieval_lambda.function_arn,
         )
 
+        effective_vault_account_id = Fn.condition_if(
+            stack_info.cfn_conditions.is_cross_account_vault_condition.logical_id,
+            stack_info.parameters.source_vault_account_id_parameter.value_as_string,
+            Aws.ACCOUNT_ID,
+        ).to_string()
+
         extend_download_window_initiate_archive_retrieval_lambda_policy = iam.Policy(
             stack_info.scope,
             "ExtendDownloadInitiateRetrievalLambdaPolicy",
@@ -143,7 +149,12 @@ class Workflow:
                         "glacier:InitiateJob",
                     ],
                     resources=[
-                        f"arn:{Aws.PARTITION}:glacier:{Aws.REGION}:{Aws.ACCOUNT_ID}:vaults/*"
+                        f"arn:{Aws.PARTITION}:glacier:{Aws.REGION}:{Aws.ACCOUNT_ID}:vaults/*",
+                        Fn.join("", [
+                            f"arn:{Aws.PARTITION}:glacier:{Aws.REGION}:",
+                            effective_vault_account_id,
+                            ":vaults/*",
+                        ]),
                     ],
                 ),
             ],
@@ -155,7 +166,7 @@ class Workflow:
             lambda_function=stack_info.lambdas.extend_download_window_initiate_retrieval_lambda,
             payload=sfn.TaskInput.from_object(
                 {
-                    "AccountId": Stack.of(stack_info.scope).account,
+                    "AccountId": effective_vault_account_id,
                     "SNSTopic": stack_info.async_facilitator_topic.topic_arn,
                     "Items.$": "$.Items",
                 },

--- a/source/solution/infrastructure/workflows/get_inventory.py
+++ b/source/solution/infrastructure/workflows/get_inventory.py
@@ -3,7 +3,7 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from aws_cdk import Aws, CfnElement, CfnOutput, Duration, Stack
+from aws_cdk import Aws, CfnElement, CfnOutput, Duration, Fn, Stack
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_stepfunctions as sfn
 from aws_cdk import aws_stepfunctions_tasks as tasks
@@ -104,6 +104,12 @@ class Workflow:
             value=stack_info.lambdas.initiate_inventory_retrieval_lambda.function_arn,
         )
 
+        effective_vault_account_id = Fn.condition_if(
+            stack_info.cfn_conditions.is_cross_account_vault_condition.logical_id,
+            stack_info.parameters.source_vault_account_id_parameter.value_as_string,
+            Aws.ACCOUNT_ID,
+        ).to_string()
+
         initiate_inventory_retrieval_lambda_policy = iam.Policy(
             stack_info.scope,
             "InitiateInventoryRetrievalLambdaPolicy",
@@ -114,7 +120,12 @@ class Workflow:
                         "glacier:InitiateJob",
                     ],
                     resources=[
-                        f"arn:{Aws.PARTITION}:glacier:{Aws.REGION}:{Aws.ACCOUNT_ID}:vaults/*"
+                        f"arn:{Aws.PARTITION}:glacier:{Aws.REGION}:{Aws.ACCOUNT_ID}:vaults/*",
+                        Fn.join("", [
+                            f"arn:{Aws.PARTITION}:glacier:{Aws.REGION}:",
+                            effective_vault_account_id,
+                            ":vaults/*",
+                        ]),
                     ],
                 ),
             ],
@@ -145,7 +156,7 @@ class Workflow:
             lambda_function=stack_info.lambdas.initiate_inventory_retrieval_lambda,
             payload=sfn.TaskInput.from_object(
                 {
-                    "accountId": Stack.of(stack_info.scope).account,
+                    "accountId": effective_vault_account_id,
                     "jobParameters": {
                         "Type": GlacierJobType.INVENTORY_RETRIEVAL,
                         "Format": "CSV",
@@ -371,6 +382,11 @@ class Workflow:
                     actions=["glacier:GetJobOutput"],
                     resources=[
                         f"arn:{Aws.PARTITION}:glacier:{Aws.REGION}:{Aws.ACCOUNT_ID}:vaults/*",
+                        Fn.join("", [
+                            f"arn:{Aws.PARTITION}:glacier:{Aws.REGION}:",
+                            effective_vault_account_id,
+                            ":vaults/*",
+                        ]),
                     ],
                 ),
             ],
@@ -427,6 +443,7 @@ class Workflow:
                 "UploadId.$": "$.multipart_upload_result.UploadId",
                 "PartNumber.$": "States.MathAdd($$.Map.Item.Index, 1)",
                 "WorkflowRun.$": "$.workflow_run",
+                "VaultAccountId": effective_vault_account_id,
             },
             retry=retrieve_inventory_map_retry.custom_state_params(),
         )

--- a/source/solution/infrastructure/workflows/initiate_retrieval.py
+++ b/source/solution/infrastructure/workflows/initiate_retrieval.py
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import json
-from aws_cdk import Aws, CfnElement, CfnOutput, Duration, Stack
+from aws_cdk import Aws, CfnElement, CfnOutput, Duration, Fn, Stack
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_lambda as lambda_
 from aws_cdk import aws_stepfunctions as sfn
@@ -72,6 +72,12 @@ class Workflow:
             value=stack_info.lambdas.initiate_archive_retrieval_lambda.function_name,
         )
 
+        effective_vault_account_id = Fn.condition_if(
+            stack_info.cfn_conditions.is_cross_account_vault_condition.logical_id,
+            stack_info.parameters.source_vault_account_id_parameter.value_as_string,
+            Aws.ACCOUNT_ID,
+        ).to_string()
+
         initiate_archive_retrieval_lambda_policy = iam.Policy(
             stack_info.scope,
             "InitiateArchiveRetrievalLambdaPolicy",
@@ -82,7 +88,12 @@ class Workflow:
                         "glacier:InitiateJob",
                     ],
                     resources=[
-                        f"arn:{Aws.PARTITION}:glacier:{Aws.REGION}:{Aws.ACCOUNT_ID}:vaults/*"
+                        f"arn:{Aws.PARTITION}:glacier:{Aws.REGION}:{Aws.ACCOUNT_ID}:vaults/*",
+                        Fn.join("", [
+                            f"arn:{Aws.PARTITION}:glacier:{Aws.REGION}:",
+                            effective_vault_account_id,
+                            ":vaults/*",
+                        ]),
                     ],
                 ),
             ],
@@ -99,7 +110,7 @@ class Workflow:
             lambda_function=stack_info.lambdas.initiate_archive_retrieval_lambda,
             payload=sfn.TaskInput.from_object(
                 {
-                    "AccountId": Stack.of(stack_info.scope).account,
+                    "AccountId": effective_vault_account_id,
                     "SNSTopic": stack_info.async_facilitator_topic.topic_arn,
                     "Items.$": "$.Items",
                 },

--- a/source/solution/infrastructure/workflows/stack_info.py
+++ b/source/solution/infrastructure/workflows/stack_info.py
@@ -78,6 +78,7 @@ class Interfaces:
 @dataclass
 class Parameters:
     destination_bucket_parameter: CfnParameter | None = field(default=None)
+    source_vault_account_id_parameter: CfnParameter | None = field(default=None)
     enable_ddb_backup_parameter: CfnParameter | None = field(default=None)
     enable_step_function_logging_parameter: CfnParameter | None = field(default=None)
     enable_lambda_tracing_parameter: CfnParameter | None = field(default=None)
@@ -87,6 +88,7 @@ class Parameters:
 @dataclass
 class CfNConditions:
     is_gov_cn_partition_condition: CfnCondition | None = field(default=None)
+    is_cross_account_vault_condition: CfnCondition | None = field(default=None)
 
 
 @dataclass


### PR DESCRIPTION
Adds the ability to migrate archives from a Glacier vault in a different AWS account than the destination S3 bucket. The source account ID is provided as an optional CloudFormation parameter at deploy time. When left empty, the solution behaves identically to a same-account transfer.

**Prerequisites for cross-account usage:**
- A vault access policy must be set on the source vault granting glacier:InitiateJob and glacier:GetJobOutput to the destination account.

**Changes:**
- Added SourceVaultAccountIdParameter and IsCrossAccountVaultCondition to the CDK stack, used via Fn::If to resolve the effective vault account ID at deploy time
- Updated all Glacier API call paths (InitiateJob, GetJobOutput) across inventory retrieval, archive retrieval, and download window extension workflows to pass the resolved source account ID instead of the hardcoded deploying account
- Expanded IAM policies for glacier:InitiateJob and glacier:GetJobOutput to include resource ARNs for both the current account and the source vault account
- Updated SNS topic policy AWS:SourceOwner condition to use the source account ID so cross-account Glacier can publish job completion notifications
- Added vault_account_id field to the DynamoDB metadata model so the account ID persists through the async chunk retrieval and download path
- Added VaultAccountId to SQS chunk messages and the inventory distributed map item selector so it flows end-to-end through all Lambda handlers
- Updated README Step 4 with collapsible same-account and cross-account deployment sections, including vault access policy setup instructions
- Added defusedxml as a Glue job dependency (--additional-python-modules)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
